### PR TITLE
Improve license information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,0 @@
-Apache-2.0 AND AGPL-3.0-or-later

--- a/README.md
+++ b/README.md
@@ -176,4 +176,4 @@ mix phx.server
 You can now access the API at http://localhost:3000.
 
 ## License
-This project is licensed under the AGPLv3 ([LICENSE](LICENSE-AGPL-3.0)) and the Apache License, Version 2.0 ([LICENSE](LICENSE-Apache-2.0)). Except the cozyauth-multi-tenant subproject, which is licensed under the AGPLv3 ([LICENSE](LICENSE-AGPL-3.0)) only.
+This project is mostly licensed under the AGPLv3 ([LICENSE](LICENSE-AGPL-3.0)) or the Apache License, Version 2.0 ([LICENSE](LICENSE-Apache-2.0)). Except the cozyauth-multi-tenant subproject, which is licensed under the AGPLv3 ([LICENSE](LICENSE-AGPL-3.0)) only.

--- a/cozyauth-cli/Cargo.toml
+++ b/cozyauth-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cozyauth-cli"
 version = "0.1.0"
 edition = "2021"
+license = "AGPL-3.0-or-later OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cozyauth-cli/src/bin/cozyauth-cli/main.rs
+++ b/cozyauth-cli/src/bin/cozyauth-cli/main.rs
@@ -1,3 +1,6 @@
+// © Copyright 2024 Jan Ehrhardt
+// SPDX-License-Identifier: AGPL-3.0-or-later OR Apache-2.0
+
 fn main() {
     println!("Hello, world!");
 }

--- a/cozyauth-multi-tenant/Cargo.toml
+++ b/cozyauth-multi-tenant/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cozyauth-multi-tenant"
 version = "0.1.0"
 edition = "2021"
+license = "AGPL-3.0-or-later"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cozyauth-multi-tenant/LICENSE
+++ b/cozyauth-multi-tenant/LICENSE
@@ -1,1 +1,0 @@
-AGPL-3.0-or-later

--- a/cozyauth-multi-tenant/LICENSE
+++ b/cozyauth-multi-tenant/LICENSE
@@ -1,0 +1,1 @@
+AGPL-3.0-or-later

--- a/cozyauth-multi-tenant/README.md
+++ b/cozyauth-multi-tenant/README.md
@@ -1,0 +1,5 @@
+# cozyauth-multi-tenant
+Cozy Auth multi-tenant server, which is used by cozyauth.cloud service.
+
+## License
+This subdirectory is licensed under the AGPL-3.0 license only. See the [LICENSE](../LICENSE-AGPL-3.0-or-later) file for details.

--- a/cozyauth-multi-tenant/src/bin/cozyauth-multi-tenant/main.rs
+++ b/cozyauth-multi-tenant/src/bin/cozyauth-multi-tenant/main.rs
@@ -1,3 +1,6 @@
+// © Copyright 2024 Jan Ehrhardt
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 fn main() {
     println!("Hello, world!");
 }

--- a/cozyauth-server/Cargo.toml
+++ b/cozyauth-server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cozyauth"
 version = "0.1.0"
 edition = "2021"
+license = "AGPL-3.0-or-later OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cozyauth-server/src/api/health.rs
+++ b/cozyauth-server/src/api/health.rs
@@ -1,3 +1,6 @@
+// © Copyright 2024 Jan Ehrhardt
+// SPDX-License-Identifier: AGPL-3.0-or-later OR Apache-2.0
+
 use axum::{routing::get, Router};
 
 pub(crate) fn router() -> Router {

--- a/cozyauth-server/src/api/mod.rs
+++ b/cozyauth-server/src/api/mod.rs
@@ -1,1 +1,4 @@
+// © Copyright 2024 Jan Ehrhardt
+// SPDX-License-Identifier: AGPL-3.0-or-later OR Apache-2.0
+
 pub(crate) mod health;

--- a/cozyauth-server/src/app.rs
+++ b/cozyauth-server/src/app.rs
@@ -1,3 +1,6 @@
+// © Copyright 2024 Jan Ehrhardt
+// SPDX-License-Identifier: AGPL-3.0-or-later OR Apache-2.0
+
 use crate::api::health;
 use axum::Router;
 

--- a/cozyauth-server/src/bin/cozyauth-server/main.rs
+++ b/cozyauth-server/src/bin/cozyauth-server/main.rs
@@ -1,3 +1,6 @@
+// © Copyright 2024 Jan Ehrhardt
+// SPDX-License-Identifier: AGPL-3.0-or-later OR Apache-2.0
+
 use cozyauth::app;
 use tokio::net::TcpListener;
 

--- a/cozyauth-server/src/lib.rs
+++ b/cozyauth-server/src/lib.rs
@@ -1,2 +1,5 @@
+// © Copyright 2024 Jan Ehrhardt
+// SPDX-License-Identifier: AGPL-3.0-or-later OR Apache-2.0
+
 pub(crate) mod api;
 pub mod app;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated licensing information across the project to reflect the use of AGPLv3 or Apache License, Version 2.0. Specific exception for the cozyauth-multi-tenant subproject, which is under AGPLv3.
- **New Features**
	- Introduced a new Cozy Auth multi-tenant server for the cozyauth.cloud service, with licensing under AGPL-3.0.
- **Chores**
	- Added copyright and license notices across various files in the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->