### PR TITLE
Commercial Open Source

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,9 @@
+Portions of this software are licensed as follows:
+
+* All content residing under the "doc/" directory of this repository is licensed under "Creative Commons: CC BY-SA 4.0 license" as defined on https://creativecommons.org/licenses/by-sa/4.0/.
+* All content that resides under the "ee/" directory of this repository, is licensed under the license defined in "ee/LICENSE".
+* Content outside of the above mentioned directories or restrictions above is available under the "Apache-2.0" license as defined below.
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -1,0 +1,44 @@
+The Cozy Auth Commercial License (the “Commercial License”)
+Copyright © 2024 Cozy Bytes GmbH
+
+With regard to the Cozy Auth Software:
+
+This software and associated documentation files (the "Software") may only be
+used in production, if you (and any entity that you represent) have agreed to,
+and are in compliance with, the Cozy Auth Subscription Terms of Service,
+available at https://cozyauth.dev/terms, or other agreement governing the use
+of the Software, as agreed by you and Cozy Bytes GmbH, and otherwise have a
+valid Cozy Auth Enterprise Edition subscription for the correct number of
+domains. Subject to the foregoing sentence, you are free to modify this
+Software and publish patches to the Software. You agree that Cozy Bytes GmbH
+and/or its licensors (as applicable) retain all right, title and interest in
+and to all such modifications and/or patches, and all such modifications and/or
+patches may only be used, copied, modified, displayed, distributed, or
+otherwise exploited with a valid Commercial Subscription for the correct
+number of domains. Notwithstanding the foregoing, you may copy and modify the
+Software for development and testing purposes, without requiring a
+subscription. You agree that Cozy Bytes GmbH and/or its licensors (as
+applicable) retain all right, title and interest in and to all such
+modifications. You are not granted any other rights beyond what is expressly
+stated herein. Subject to the foregoing, it is forbidden to copy, merge,
+publish, distribute, sublicense, and/or sell the Software.
+
+This Commercial License applies only to the part of this Software that is not
+distributed under the Apache-2.0 license. Any part of this Software
+is served client-side as an image, font, cascading stylesheet (CSS), file which
+produces or is compiled, arranged, augmented, or combined into client-side
+JavaScript, in whole or in part, is copyrighted under the Apache-2.0 license.
+The full text of this Commercial License shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+For all third party components incorporated into the Cozy Auth Software, those
+components are licensed under the original license provided by the owner of the
+applicable component.


### PR DESCRIPTION
In #182 the license has been changed from `AGPL-3.0-or-later` to the more permissive `Apache-2.0`. While doing this, also the commercial license has been removed.

With this pull request, the commercial license is introduced again to keep the opportunity of adding some code that is not under a free license. This will help to keep the project as a monolithic repo.