### PR TITLE
Add license header check to Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,11 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  check-license-header:
+    name: Check License Headers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check License Header
+        uses: apache/skywalking-eyes/header@v0.6.0

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,29 @@
+# © Copyright 2024 Cozy Bytes GmbH
+
+header:
+  - license:
+      spdx-id: Apache-2.0
+      copyright-owner: Cozy Auth Contributors
+      copyright-year: "2024"
+    paths-ignore:
+      - ".dockerignore"
+      - ".editorconfig"
+      - ".env-example"
+      - "Dockerfile"
+      - "Cargo.lock"
+      - ".gitignore"
+      - "LICENSE"
+      - "README.md"
+      - ".sqlx/**"
+      - "ee/**"
+      - "target/**"
+      - "**/*.toml"
+      - "**/*.yml"
+      - "**/*.yaml"
+  - license:
+      content: © Copyright 2024 Cozy Bytes GmbH
+    paths:
+      - "ee/**"
+    paths-ignore:
+      - "LICENSE"
+      - "**/*.toml"

--- a/cli/src/bin/cozyauth-cli/main.rs
+++ b/cli/src/bin/cozyauth-cli/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Cozy Auth Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use cozyauth_cli::cli;
 
 #[tokio::main]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Cozy Auth Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use clap::{Args, Parser, Subcommand};
 
 #[derive(Debug, Parser)]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,1 +1,15 @@
+// Copyright 2024 Cozy Auth Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub mod cli;

--- a/ee/cloud/src/app.rs
+++ b/ee/cloud/src/app.rs
@@ -1,3 +1,5 @@
+// © Copyright 2024 Cozy Bytes GmbH
+
 use std::env;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 

--- a/ee/cloud/src/bin/cozyauth-cloud/main.rs
+++ b/ee/cloud/src/bin/cozyauth-cloud/main.rs
@@ -1,3 +1,5 @@
+// © Copyright 2024 Cozy Bytes GmbH
+
 use cozyauth_cloud::app;
 
 #[tokio::main]

--- a/ee/cloud/src/lib.rs
+++ b/ee/cloud/src/lib.rs
@@ -1,1 +1,3 @@
+// © Copyright 2024 Cozy Bytes GmbH
+
 pub mod app;

--- a/server/migrations/20240709204200_create_table_registrations.down.sql
+++ b/server/migrations/20240709204200_create_table_registrations.down.sql
@@ -1,1 +1,15 @@
+-- Copyright 2024 Cozy Auth Contributors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 drop table if exists registrations;

--- a/server/migrations/20240709204200_create_table_registrations.up.sql
+++ b/server/migrations/20240709204200_create_table_registrations.up.sql
@@ -1,3 +1,17 @@
+-- Copyright 2024 Cozy Auth Contributors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 create table registrations (
     id uuid not null default gen_random_uuid(),
     user_id uuid not null,

--- a/server/migrations/20240728150214_create_table_passkeys.down.sql
+++ b/server/migrations/20240728150214_create_table_passkeys.down.sql
@@ -1,1 +1,15 @@
+-- Copyright 2024 Cozy Auth Contributors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 drop table if exists passkeys;

--- a/server/migrations/20240728150214_create_table_passkeys.up.sql
+++ b/server/migrations/20240728150214_create_table_passkeys.up.sql
@@ -1,3 +1,17 @@
+-- Copyright 2024 Cozy Auth Contributors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 create table passkeys (
     id uuid not null default gen_random_uuid(),
     user_id uuid not null,

--- a/server/migrations/20240728194947_add_passkey_id_to_registrations_table.down.sql
+++ b/server/migrations/20240728194947_add_passkey_id_to_registrations_table.down.sql
@@ -1,3 +1,17 @@
+-- Copyright 2024 Cozy Auth Contributors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 alter table registrations
 drop constraint if exists registrations_passkey_id_fkey;
 

--- a/server/migrations/20240728194947_add_passkey_id_to_registrations_table.up.sql
+++ b/server/migrations/20240728194947_add_passkey_id_to_registrations_table.up.sql
@@ -1,3 +1,17 @@
+-- Copyright 2024 Cozy Auth Contributors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 alter table registrations
 add column passkey_id uuid;
 

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -1,1 +1,15 @@
+// Copyright 2024 Cozy Auth Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub(crate) mod passkeys;

--- a/server/src/api/passkeys.rs
+++ b/server/src/api/passkeys.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Cozy Auth Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use axum::{
     extract::{Path, State},
     http::StatusCode,

--- a/server/src/app.rs
+++ b/server/src/app.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Cozy Auth Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use axum::{routing::get, Json, Router};

--- a/server/src/bin/cozyauth-server/main.rs
+++ b/server/src/bin/cozyauth-server/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Cozy Auth Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[tokio::main]
 async fn main() {
     cozyauth_server::cli::run().await;

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Cozy Auth Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use clap::{Parser, Subcommand};
 
 use crate::{app::start_server, config::Settings, db::migrate};

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Cozy Auth Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use url::Url;
 
 #[derive(Clone, Debug, serde::Deserialize)]

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Cozy Auth Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use sqlx::{migrate::Migrator, PgPool};
 
 use crate::config::Settings;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Cozy Auth Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod api;
 mod app;
 pub mod cli;

--- a/server/src/model/mod.rs
+++ b/server/src/model/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Cozy Auth Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub(crate) mod passkey;
 pub(crate) mod registration;
 pub(crate) mod webauthn_utils;

--- a/server/src/model/passkey.rs
+++ b/server/src/model/passkey.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Cozy Auth Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use sqlx::types::Json;
 use sqlx::FromRow;
 use uuid::Uuid;

--- a/server/src/model/registration.rs
+++ b/server/src/model/registration.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Cozy Auth Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use chrono::{DateTime, Utc};
 use sqlx::{prelude::FromRow, types::Json, PgPool};
 use url::Url;

--- a/server/src/model/webauthn_utils.rs
+++ b/server/src/model/webauthn_utils.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Cozy Auth Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use url::Url;
 use webauthn_rs::prelude::*;
 


### PR DESCRIPTION
This Github action will ensure that all Rust source files have a License header. When someone copies code from this project, the header will highlight, if this permitted under `Apache-2.0` or not.